### PR TITLE
Add image upload to budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Set up the environment variables
 
     BASE_MEDIA_ROOT
     MEDIA_URL
-    SESSION_MEDIA_FOLDER
+    BUDGET_MEDIA_FOLDER
     ALLOWED_HOSTS
     
     DEFAULT_DATABASE_NAME
@@ -68,7 +68,7 @@ Example:
 
     export BASE_MEDIA_ROOT='/home/fulanito/Projects/dotp_media/'
     export MEDIA_URL='http://10.0.0.207/'
-    export SESSION_MEDIA_FOLDER='session_media'
+    export BUDGET_MEDIA_FOLDER='budget_media'
     export ALLOWED_HOSTS='0.0.0.0,127.0.0.1'
     
     export DEFAULT_DATABASE_NAME='dotp_db'

--- a/discipline_of_the_poor/budget/models/budget.py
+++ b/discipline_of_the_poor/budget/models/budget.py
@@ -7,6 +7,26 @@ from budget.models.mixins import BaseMixin
 from budget.models.movement import Movement
 from dotp_users.models.mixins import OwnershipMixin
 import reversion
+from django.conf import settings
+import os
+
+
+def get_storage_path(instance, filename):
+    """
+    Function used to fetch the absolute path to store the image.
+    The path is created by appending the base media path and the
+    user unique id as the path, and the date plus the given
+    @filename as the file name
+    :param Budget instance: the instance of the obj to
+                                     store
+    :param filename: the given file name
+    :return str path: the path of the file to save
+    """
+    user_id = str(instance.owner_id)
+    file_name = str(instance.create_date.date()) + '_' + filename
+    file_path = os.path.join(
+        settings.BUDGET_MEDIA_FOLDER, user_id, file_name)
+    return file_path
 
 
 @reversion.register()
@@ -18,4 +38,8 @@ class Budget(BaseMixin, OwnershipMixin):
         Movement,
         through='BudgetMovement',
         related_name='budgets',
+    )
+    photo = models.ImageField(
+        upload_to=get_storage_path,
+        null=True,
     )

--- a/discipline_of_the_poor/budget/serializers/budget_serializer.py
+++ b/discipline_of_the_poor/budget/serializers/budget_serializer.py
@@ -34,6 +34,7 @@ class BudgetSerializer(OwnerModelSerializerMixin):
             'available_amount',
             'movement_objects',
             'stats',
+            'photo',
         ]
         examples = {
             "id": 1,

--- a/discipline_of_the_poor/discipline_of_the_poor/settings.py
+++ b/discipline_of_the_poor/discipline_of_the_poor/settings.py
@@ -29,6 +29,11 @@ DEBUG = True
 
 ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS').split(',')
 
+# Media handling
+
+MEDIA_ROOT = os.environ.get('BASE_MEDIA_ROOT')
+MEDIA_URL = os.environ.get('MEDIA_URL')
+BUDGET_MEDIA_FOLDER = os.environ.get('BUDGET_MEDIA_FOLDER')
 
 # Application definition
 

--- a/docs/IMAGES.md
+++ b/docs/IMAGES.md
@@ -1,0 +1,54 @@
+# Image upload
+
+To upload images, a couple of steps are needed, mainly configuration ones,
+because django takes care of the multipart form and the data type conversions
+
+### Storage
+
+The image is stored on disk instead of the database, and the field in the
+database is a path to the file in disk (not an absolute path).
+
+To determine the upload path, a dedicated folder is created, and then
+a folder for each user, along with the uploaded file with its timestamp
+appended.
+
+To configure it, set the variables:
+
+    # Media handling
+
+    MEDIA_ROOT = os.environ.get('BASE_MEDIA_ROOT')
+    MEDIA_URL = os.environ.get('MEDIA_URL')
+    BUDGET_MEDIA_FOLDER = os.environ.get('BUDGET_MEDIA_FOLDER')
+
+### Serving
+
+After the file is stored, the list resources show the MEDIA_URL + the
+stored path of the file. To serve it to the users, a web server must be set up.
+
+##### Nginx
+
+To use nginx, after installing it, configure a new site for this project by
+creating the file:
+
+    /etc/nginx/sites-enabled/dotp
+    
+With contents as such:
+
+    server {
+        server_name localhost;
+        listen 127.0.0.1:80;
+        listen 10.0.0.207:80;
+    
+        location /budget_media/ {
+            root /home/fulanito/Projects/dotp_media;
+        }
+            
+    } 
+
+And then activate it by creating a symlink:
+
+    ln -s /etc/nginx/sites-available/dotp /etc/nginx/sites-enabled/dotp
+    
+Restart the server and you should be able to access the file:
+
+    sudo service nginx restart

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,3 +7,4 @@ djangorestframework-guardian==0.3.0
 djangorestframework-simplejwt==4.4.0
 drf-yasg==1.17.1
 drf-yasg-examples==0.1.1
+pillow==7.2.0


### PR DESCRIPTION
The budget needs to allow for a picture to be
attached, stored, and served with a web server